### PR TITLE
[fix] homepage link

### DIFF
--- a/templates/index.twig
+++ b/templates/index.twig
@@ -5,7 +5,7 @@
 {% set defaultText %}
   <h1>Welcome!</h1>
   <p>This is a pre-configured <a href="https://www.craftcms.com">Craft CMS</a> installation, created by <a href="https://www.village.one">Village One</a>. Please check out the Readme in the project root or on Github for first steps.</p>
-  <p><a class="button" href="https://github.com/village-one/village-craft/blob/main/README.md">Open Readme on GitHub</a></p>
+  <p><a class="button" href="https://github.com/village-one/ptf-site/blob/main/README.md">Open Readme on GitHub</a></p>
 {% endset %}
 
 {% block content %}


### PR DESCRIPTION
This PR fixes the button on the standard homepage template pointing to the wrong readme (leftover from our template repo).