### PR TITLE
[Fix] Deployment workflow

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -11,8 +11,9 @@ jobs:
     steps:
       - name: Checking out git
         uses: actions/checkout@v4
-      - name: Prepare repository
-        run: git checkout "${GITHUB_REF:11}"
+        with:
+          ref: production
+          fetch-depth: 0
       - name: Setup SSH key
         run: |
           mkdir -p $HOME/.ssh

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -11,8 +11,9 @@ jobs:
     steps:
       - name: Checking out git
         uses: actions/checkout@v4
-      - name: Prepare repository
-        run: git checkout "${GITHUB_REF:11}"
+        with:
+          ref: staging
+          fetch-depth: 0
       - name: Setup SSH key
         run: |
           mkdir -p $HOME/.ssh


### PR DESCRIPTION
GitHub Action version 2 started to only fetch the latest commit, instead of the entire history, which unfortunately breaks our `git push -u fortrabbit $ref:main` with this error: 

<img width="585" alt="image" src="https://github.com/user-attachments/assets/0cf4fa0b-fac7-4ae3-81e7-63be84ee31a9" />

Setting the `fetch-depth = 0` changes it back to fetching all history for all branches and tags.  

According [the documentation](https://github.com/actions/checkout/tree/releases/v4.0.0?tab=readme-ov-file#usage), adding the `ref` here isn't strictly necessary and is already pointing to the branch that triggered the action, I think. But I did it, to be more precise. 