### PR TITLE
[fix] default button color

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -135,5 +135,5 @@
 }
 
 .button {
-  @apply relative leading-none inline-block align-middle overflow-hidden whitespace-nowrap text-ellipsis max-w-full text-white rounded-3xl mr-1.5 px-2.5 py-1.25 hover:bg-gray-700 decoration-0 active:bg-gray-800 dark:text-gray-700 dark:bg-gray-400 dark:hover:bg-gray-200 dark:active:bg-gray-100;
+  @apply relative leading-none inline-block align-middle overflow-hidden whitespace-nowrap text-ellipsis max-w-full text-white rounded-3xl mr-1.5 px-2.5 py-1.25 bg-gray-500 hover:bg-gray-700 decoration-0 active:bg-gray-800 dark:text-gray-700 dark:bg-gray-400 dark:hover:bg-gray-200 dark:active:bg-gray-100;
 }


### PR DESCRIPTION
The default button styles were missing a background color in light mode, rendering the button invisible. Probably doesn’t matter that much, since we’ll most likely throw out this boilerplate code anyways. Still, didn’t want it to look broken until we get to build the real frontend.