### PR TITLE
[chore] schedule dependabot checks for weekly npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Let's add this check also, currently the security checks are only configured through the "Security" configs tab in GitHub. 